### PR TITLE
[FEAT] - Add warning messages if robot on edge or a corner

### DIFF
--- a/internal/robot/warning.go
+++ b/internal/robot/warning.go
@@ -1,6 +1,25 @@
 package robot
 
-import "math/rand"
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/robotAssignment/internal/board"
+)
+
+type cornerCoordinates struct {
+	row    int
+	column int
+}
+
+type Corner string
+
+const (
+	TopLeft     Corner = "TopLeft"
+	TopRight    Corner = "TopRight"
+	BottomLeft  Corner = "BottomLeft"
+	BottomRight Corner = "BottomRight"
+)
 
 var warning = []string{
 	"Lookout Chief -You are about to fall off the board!",
@@ -10,12 +29,42 @@ var warning = []string{
 	"You can do better Mr. Robot, don't fall off now!!",
 }
 
-// Warning returns a random warning message
-func Warning() string {
+func warningMessage() string {
 	return warning[randInt(0, len(warning)-1)]
 }
 
-// randInt returns a random integer between min and max
 func randInt(min int, max int) int {
 	return min + rand.Intn(max-min)
+}
+
+func getCornerDirections(c Corner) string {
+	switch c {
+	case TopLeft:
+		return fmt.Sprintf("%s and %s", DirectionNorth, DirectionWest)
+	case TopRight:
+		return fmt.Sprintf("%s and %s", DirectionNorth, DirectionEast)
+	case BottomLeft:
+		return fmt.Sprintf("%s and %s", DirectionSouth, DirectionWest)
+	case BottomRight:
+		return fmt.Sprintf("%s and %s", DirectionSouth, DirectionEast)
+	default:
+		return ""
+	}
+}
+
+func getBoardCornerCoordinates(b *board.Board) map[Corner][]cornerCoordinates {
+	return map[Corner][]cornerCoordinates{
+		TopLeft: {
+			{row: 0, column: 0},
+		},
+		TopRight: {
+			{row: 0, column: b.MaxColumns - 1},
+		},
+		BottomLeft: {
+			{row: b.MaxRows - 1, column: 0},
+		},
+		BottomRight: {
+			{row: b.MaxRows - 1, column: b.MaxColumns - 1},
+		},
+	}
 }


### PR DESCRIPTION
Add random message warnings when the robot reaches edge of the board or is at a corner coordinate and points out the danger direction.